### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "keywords": ["zoom", "web", "sdk"],
     "author": "Jack Yang",
-    "license": "MIT",
+    "license": "SEE LICENSE IN LICENSE.md",
     "homepage": "https://github.com/zoom/websdk#readme",
     "bugs": {
         "url": "https://github.com/zoom/websdk/issues"


### PR DESCRIPTION
Currently, the `@zoom/websdk` package is being erroneously listed on NPM as an MIT-licensed package. This pull request corrects that.